### PR TITLE
Added Observer Razor Component

### DIFF
--- a/src/Cortex.Net.Blazor/Observer.cs
+++ b/src/Cortex.Net.Blazor/Observer.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="Observer.cs" company="Jan-Willem Spuij">
+// Copyright 2019 Jan-Willem Spuij
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom
+// the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+namespace Cortex.Net.Blazor
+{
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Rendering;
+
+    /// <summary>
+    /// Sometimes it is hard to apply Observer to a part of the rendering,
+    /// for example because you are rendering inside a RenderFragment,
+    /// and you don't want to extract a new component to be able to mark it as observer.
+    /// In those cases <Observer /> comes in handy. It takes a child content that
+    /// is automatically re-rendered if any referenced observables change.
+    /// </summary>
+    [Observer]
+    public class Observer : ComponentBase
+    {
+        /// <summary>
+        /// Gets or sets the wrapped child content of the component.
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <inheritdoc/>
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            this.ChildContent?.Invoke(builder);
+        }
+    }
+}


### PR DESCRIPTION
In documentation section [Observer](https://jspuij.github.io/Cortex.Net.Docs/pages/observer.html#tips) there is a tips section where a <Observer> razor component is described. In source code this component now doesn't exists. 